### PR TITLE
Clarify non-native @JsType support for Java 16 records

### DIFF
--- a/java/jsinterop/annotations/JsProperty.java
+++ b/java/jsinterop/annotations/JsProperty.java
@@ -27,8 +27,8 @@ import java.lang.annotation.Target;
  *
  * <p>If it is applied to a method, it will be treated as a property accessor. As a result, instead
  * of translating method calls to JsProperty methods as method calls in JS, they will be translated
- * as property lookups. When a JsProperty method implemented by a Java class, such methods will be
- * generated as property accessor in JavaScript, hence the property access will trigger the
+ * as property lookups. When a JsProperty method is implemented by a Java class, such methods will
+ * be generated as property accessors in JavaScript, hence the property access will trigger the
  * execution of the matching getter or setter methods.
  *
  * <p>JsProperty follows JavaBean style naming convention to extract the default property name. If
@@ -38,6 +38,11 @@ import java.lang.annotation.Target;
  *   <li>{@code @JsProperty getX()} or {@code @JsProperty isX()} translates as {@code this.x}
  *   <li>{@code @JsProperty setX(int y)} translates as {@code this.x=y}
  * </ul>
+ *
+ * <p>When applied to {@code record} components, the annotation will only apply to the accessor and
+ * not to the field - otherwise this would result in a naming conflict. Additionally, the JavaBean
+ * style convention is not required, as record accessors do not being with {@code get-} or
+ * {@code is-}.
  *
  * <p>Note: In JavaScript, instance members are defined on the prototype and class members are
  * defined on the constructor function of the type which mimics ES6 class style.

--- a/java/jsinterop/annotations/JsType.java
+++ b/java/jsinterop/annotations/JsType.java
@@ -48,9 +48,6 @@ import java.lang.annotation.Target;
  * <p>For native interfaces with no particular JavaScript type associated with them (e.g. structural
  * types) it is recommended to use {@code namespace = JsPackage.GLOBAL} and {@code name = '?'}.
  *
- * <p>If a Java {@code record} is marked a "non-native" JsType  public accessor methods are treated
- * as though they are annotated with {@link JsProperty}.
- *
  * <p><b>Instanceof and Castability:</b>
  *
  * <p>If the JsType is native, the generated code will try to mimic Javascript semantics.

--- a/java/jsinterop/annotations/JsType.java
+++ b/java/jsinterop/annotations/JsType.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *
  * <p>Marking an object with JsType is similar to marking each public member of the class with
  * {@link JsProperty}/{@link JsMethod}/{@link JsConstructor} respectively. In order for this to work
- * correctly the JavaScript name needs to be unique for each member. Some unobvious ways to cause
+ * correctly the JavaScript name needs to be unique for each member. Some nonobvious ways to cause
  * name collisions are:
  *
  * <ul>
@@ -47,6 +47,9 @@ import java.lang.annotation.Target;
  *
  * <p>For native interfaces with no particular JavaScript type associated with them (e.g. structural
  * types) it is recommended to use {@code namespace = JsPackage.GLOBAL} and {@code name = '?'}.
+ *
+ * <p>If a Java {@code record} is marked a "non-native" JsType  public accessor methods are treated
+ * as though they are annotated with {@link JsProperty}.
  *
  * <p><b>Instanceof and Castability:</b>
  *


### PR DESCRIPTION
Does not attempt to address native support - like enums, if this is to be supported, it will likely require its own annotation and semantics.

Fixes #6